### PR TITLE
Add the TaskCollectionPluginInterface

### DIFF
--- a/src/Version10/TaskCollectionPluginInterface.php
+++ b/src/Version10/TaskCollectionPluginInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Phpcq\PluginApi\Version10;
+
+use Phpcq\PluginApi\Version10\Configuration\PluginConfigurationInterface;
+
+/**
+ * This plugin provides a list of task names which should be executed.
+ */
+interface TaskCollectionPluginInterface extends ConfigurationPluginInterface
+{
+    /** @return list<string> */
+    public function getTaskNames(PluginConfigurationInterface $pluginConfiguration): array;
+}


### PR DESCRIPTION
This pull request provides a new plugin interface which allows to define a plugin calling other tasks. The purpose of this interface is to implement the task chains as a plugin. This would simplify the runner and the configuration as there wouldn't be a separate chain configuration anymore.