### PR TITLE
Rather use textContent than nodeValue

### DIFF
--- a/.github/workflows/diagnostics.yml
+++ b/.github/workflows/diagnostics.yml
@@ -17,16 +17,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: 7.4
+          - php: '7.4'
             phpcq_install: 'install'
             phpcq_flags: ''
-          - php: 8.0
+          - php: '8.0'
             phpcq_install: 'update'
             phpcq_flags: ''
-          - php: 8.1
+          - php: '8.1'
             phpcq_install: 'update'
             phpcq_flags: ''
-          - php: 8.2
+          - php: '8.2'
             phpcq_install: 'update'
             phpcq_flags: '--exit-0'
 

--- a/.github/workflows/diagnostics.yml
+++ b/.github/workflows/diagnostics.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - 'release/**'
 
 jobs:
   build:

--- a/src/Version10/Util/JUnitReportAppender.php
+++ b/src/Version10/Util/JUnitReportAppender.php
@@ -109,7 +109,7 @@ final class JUnitReportAppender implements XmlReportAppenderInterface
              *
              * Text content holds error message.
              */
-            $builder = $report->addDiagnostic($severity, $this->stripRootDir($childNode->nodeValue));
+            $builder = $report->addDiagnostic($severity, $this->stripRootDir($childNode->textContent));
             if ($testCase->hasAttribute('file')) {
                 $builder->forFile($this->stripRootDir($testCase->getAttribute('file')))
                     ->forRange((int) $this->getIntXmlAttribute($testCase, 'line'))


### PR DESCRIPTION
psalm said that it is nullable in php 8.0.
Unsure if that is the case or if it is a quirk resulting from an issue in psalm but using `textContent` for the elements seems more appropriate anyway.